### PR TITLE
Added inheritance support in ReflectionConfigurator.RegisterType() method

### DIFF
--- a/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
+++ b/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
@@ -57,6 +57,13 @@ namespace ExtDirectHandler.Tests.Configuration
 		}
 
 		[Test]
+		public void Should_configure_methods_with_inheritance()
+		{
+			IMetadata actual = _target.RegisterType<ActionClass1>(true);
+			_target.GetMethodNames("ActionClass1").Should().Contain("baseMethod");
+		}
+
+		[Test]
 		public void Should_configure_formhandler_from_attribute()
 		{
 			IMetadata actual = _target.RegisterType<ActionClass3>();

--- a/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
+++ b/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
@@ -61,6 +61,8 @@ namespace ExtDirectHandler.Tests.Configuration
 		{
 			IMetadata actual = _target.RegisterType<ActionClass1>(true);
 			_target.GetMethodNames("ActionClass1").Should().Contain("baseMethod");
+			_target.GetMethodNames("ActionClass1").Should().Not.Contain("getHashCode");
+			_target.GetMethodNames("ActionClass1").Should().Not.Contain("getType");
 		}
 
 		[Test]

--- a/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
+++ b/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
@@ -29,6 +29,11 @@ namespace ExtDirectHandler.Configuration
 			return RegisterType(typeof(T));
 		}
 
+		public ReflectionConfigurator RegisterType<T>(bool inherit)
+		{
+			return RegisterType(typeof(T), inherit);
+		}
+
 		public ReflectionConfigurator RegisterTypes(IEnumerable<Type> types)
 		{
 			foreach(Type type in types)
@@ -38,15 +43,21 @@ namespace ExtDirectHandler.Configuration
 			return this;
 		}
 
-		public ReflectionConfigurator RegisterType(Type type)
+		public ReflectionConfigurator RegisterType(Type type, bool inherit)
 		{
 			AddAction(type.Name);
-			foreach(MethodInfo methodInfo in type.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance))
+			BindingFlags declaredOnly = inherit ? BindingFlags.Default : BindingFlags.DeclaredOnly;
+			foreach(MethodInfo methodInfo in type.GetMethods(declaredOnly | BindingFlags.Public | BindingFlags.Instance ))
 			{
-				DirectMethodAttribute directMethodAttribute = _reflectionHelpers.FindAttribute(methodInfo, new DirectMethodAttribute());
+				DirectMethodAttribute directMethodAttribute = _reflectionHelpers.FindAttribute(methodInfo, new DirectMethodAttribute(), inherit);
 				AddMethod(type.Name, BuildMethodName(methodInfo.Name), type, methodInfo, directMethodAttribute.FormHandler, directMethodAttribute.NamedArguments);
 			}
 			return this;
+		}
+
+		public ReflectionConfigurator RegisterType(Type type)
+		{
+			return this.RegisterType(type, false);
 		}
 
 		public ReflectionConfigurator PreserveMethodCase(bool preserveMethodCase)

--- a/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
+++ b/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
@@ -46,8 +46,10 @@ namespace ExtDirectHandler.Configuration
 		public ReflectionConfigurator RegisterType(Type type, bool inherit)
 		{
 			AddAction(type.Name);
-			BindingFlags declaredOnly = inherit ? BindingFlags.Default : BindingFlags.DeclaredOnly;
-			foreach(MethodInfo methodInfo in type.GetMethods(declaredOnly | BindingFlags.Public | BindingFlags.Instance ))
+			var methods = inherit ? 
+				_reflectionHelpers.GetInheritedMethods(type) : 
+				type.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
+			foreach (MethodInfo methodInfo in methods)
 			{
 				DirectMethodAttribute directMethodAttribute = _reflectionHelpers.FindAttribute(methodInfo, new DirectMethodAttribute(), inherit);
 				AddMethod(type.Name, BuildMethodName(methodInfo.Name), type, methodInfo, directMethodAttribute.FormHandler, directMethodAttribute.NamedArguments);

--- a/src/ExtDirectHandler/Configuration/ReflectionHelpers.cs
+++ b/src/ExtDirectHandler/Configuration/ReflectionHelpers.cs
@@ -11,9 +11,19 @@ namespace ExtDirectHandler.Configuration
 			return FindAttribute<T>(member) ?? def;
 		}
 
+		public T FindAttribute<T>(MemberInfo member, T def, bool inherit) where T : Attribute
+		{
+			return FindAttribute<T>(member, inherit) ?? def;
+		}
+
 		public T FindAttribute<T>(MemberInfo member) where T : Attribute
 		{
 			return (T)member.GetCustomAttributes(typeof(T), false).FirstOrDefault();
+		}
+
+		public T FindAttribute<T>(MemberInfo member, bool inherit) where T : Attribute
+		{
+			return (T)member.GetCustomAttributes(typeof(T), inherit).FirstOrDefault();
 		}
 
 		public bool HasAttribute<T>(MemberInfo member) where T : Attribute

--- a/src/ExtDirectHandler/Configuration/ReflectionHelpers.cs
+++ b/src/ExtDirectHandler/Configuration/ReflectionHelpers.cs
@@ -40,5 +40,14 @@ namespace ExtDirectHandler.Configuration
 			}
 			return attribute;
 		}
+
+		public MethodInfo[] GetInheritedMethods(Type type)
+		{
+			MethodInfo[] objectMethods = typeof(Object).GetMethods();
+			MethodInfo[] result = type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+				.TakeWhile(tm => !objectMethods.Contains(tm.GetBaseDefinition()))
+				.ToArray();
+			return result;
+		}
 	}
 }


### PR DESCRIPTION
Allows base class methods to be available in RPC
