### PR TITLE
Inheritance support

### DIFF
--- a/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
+++ b/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
@@ -45,7 +45,7 @@ namespace ExtDirectHandler.Tests.Configuration
 		{
 			IMetadata actual = _target.RegisterType<ActionClass1>();
 
-			_target.GetMethodNames("ActionClass1").Should().Have.SameValuesAs(new[] { "publicInstanceMethod", "methodWithParameters" });
+			_target.GetMethodNames("ActionClass1").Should().Have.SameValuesAs(new[] { "publicInstanceMethod", "methodWithParameters", "baseDirectAttributeMethod" });
 
 			_target.GetMethodInfo("ActionClass1", "publicInstanceMethod").Should().Be.SameInstanceAs(typeof(ActionClass1).GetMethod("PublicInstanceMethod"));
 			_target.IsFormHandler("ActionClass1", "publicInstanceMethod").Should().Be.False();
@@ -54,6 +54,10 @@ namespace ExtDirectHandler.Tests.Configuration
 			_target.GetMethodInfo("ActionClass1", "methodWithParameters").Should().Be.SameInstanceAs(typeof(ActionClass1).GetMethod("MethodWithParameters"));
 			_target.IsFormHandler("ActionClass1", "methodWithParameters").Should().Be.False();
 			_target.HasNamedArguments("ActionClass1", "methodWithParameters").Should().Be.False();
+
+			_target.GetMethodInfo("ActionClass1", "baseDirectAttributeMethod").Should().Be.SameInstanceAs(typeof(ActionClass1).GetMethod("BaseDirectAttributeMethod"));
+			_target.IsFormHandler("ActionClass1", "baseDirectAttributeMethod").Should().Be.False();
+			_target.HasNamedArguments("ActionClass1", "baseDirectAttributeMethod").Should().Be.False();
 		}
 
 		[Test]
@@ -77,7 +81,7 @@ namespace ExtDirectHandler.Tests.Configuration
 		{
 			_target.PreserveMethodCase(true).RegisterType<ActionClass1>();
 
-			_target.GetMethodNames("ActionClass1").Should().Have.SameValuesAs(new[] { "PublicInstanceMethod", "MethodWithParameters" });
+			_target.GetMethodNames("ActionClass1").Should().Have.SameValuesAs(new[] { "PublicInstanceMethod", "MethodWithParameters", "BaseDirectAttributeMethod" });
 		}
 
 		private class ActionClass3
@@ -92,6 +96,9 @@ namespace ExtDirectHandler.Tests.Configuration
 		private class BaseClass
 		{
 			public void BaseMethod() {}
+			
+			[DirectMethod]
+			public void BaseDirectAttributeMethod() {}
 		}
 
 		private class ActionClass1 : BaseClass

--- a/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
+++ b/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
@@ -41,7 +41,11 @@ namespace ExtDirectHandler.Configuration
 		public ReflectionConfigurator RegisterType(Type type)
 		{
 			AddAction(type.Name);
-			foreach(MethodInfo methodInfo in type.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance))
+			var baseMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance).Where(mi => _reflectionHelpers.HasAttribute<DirectMethodAttribute>(mi));
+			var instanceMethods = type.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
+			IEnumerable<MethodInfo> methods = baseMethods.Union(instanceMethods);
+
+			foreach(MethodInfo methodInfo in methods)
 			{
 				DirectMethodAttribute directMethodAttribute = _reflectionHelpers.FindAttribute(methodInfo, new DirectMethodAttribute());
 				AddMethod(type.Name, BuildMethodName(methodInfo.Name), type, methodInfo, directMethodAttribute.FormHandler, directMethodAttribute.NamedArguments);

--- a/src/ExtDirectHandler/Configuration/ReflectionHelpers.cs
+++ b/src/ExtDirectHandler/Configuration/ReflectionHelpers.cs
@@ -13,7 +13,7 @@ namespace ExtDirectHandler.Configuration
 
 		public T FindAttribute<T>(MemberInfo member) where T : Attribute
 		{
-			return (T)member.GetCustomAttributes(typeof(T), false).FirstOrDefault();
+			return (T)member.GetCustomAttributes(typeof(T), true).FirstOrDefault();
 		}
 
 		public bool HasAttribute<T>(MemberInfo member) where T : Attribute


### PR DESCRIPTION
Now base methods that are decorated with [DirectMethod] attribute are also included in the RegisterType() method.
