### PR TITLE
Add Interface Inheritance

### DIFF
--- a/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
+++ b/src/ExtDirectHandler.Tests/Configuration/ReflectionConfiguratorTest.cs
@@ -60,8 +60,10 @@ namespace ExtDirectHandler.Tests.Configuration
 		public void Should_include_decorated_inherited_methods()
 		{
 			_target.RegisterType<InheritedAction>();
-
 			_target.GetMethodNames("InheritedAction").Should().Have.SameValuesAs(new[] { "decoratedBaseMethod" });
+			
+			_target.RegisterType<InheritedInterface>();
+            _target.GetMethodNames("InheritedInterface").Should().Have.SameValuesAs(new[] { "inheritedMethod", "classMethod" }); 
 		}
 
 		[Test]
@@ -118,5 +120,14 @@ namespace ExtDirectHandler.Tests.Configuration
 		}
 
 		private class InheritedAction : BaseAction {}
+		
+		private interface IClass
+        {
+            int classMethod();
+        }
+
+        private interface InheritedInterface : IClass {
+            int inheritedMethod();
+        }
 	}
 }

--- a/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
+++ b/src/ExtDirectHandler/Configuration/ReflectionConfigurator.cs
@@ -41,8 +41,14 @@ namespace ExtDirectHandler.Configuration
 		public ReflectionConfigurator RegisterType(Type type)
 		{
 			AddAction(type.Name);
-			var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-				.Where(mi => mi.DeclaringType == type || _reflectionHelpers.HasAttribute<DirectMethodAttribute>(mi));
+			
+			var methods = new List<MethodInfo>();
+			
+            methods.AddRange(type.GetMethods(BindingFlags.Public|BindingFlags.Instance)
+                    .Where(mi => mi.DeclaringType == type || _reflectionHelpers.HasAttribute<DirectMethodAttribute>(mi)));
+
+            if (type.IsInterface) type.GetInterfaces().ToList().ForEach(x => methods.AddRange(x.GetMethods()));
+			
 			foreach(MethodInfo methodInfo in methods)
 			{
 				DirectMethodAttribute directMethodAttribute = _reflectionHelpers.FindAttribute(methodInfo, new DirectMethodAttribute());


### PR DESCRIPTION
When I need register Interface and then resolve it with IoC container
like in Project Wiki, ReflectionConfigurator not include inherited
method for Interface.
